### PR TITLE
Fix uglify async folders promise

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -36,6 +36,8 @@ gulp.task('uglify:resources:dist', function (cb) {
 	} else {
 		const colors = require('colors/safe');
 		console.log(colors.yellow('uglify resources disabled'));
+
+		cb();
 	}
 });
 
@@ -72,5 +74,7 @@ gulp.task('uglify:components:dist', function (cb) {
 	} else {
 		const colors = require('colors/safe');
 		console.log(colors.yellow('uglify components disabled'));
+
+		cb();
 	}
 });


### PR DESCRIPTION
Added a promise each time the gulp task is uglifying a folder. 
**Result ** the callback function of `uglify.js` is only called if both folders have been uglified.