### PR TITLE
Update uglify.js

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -45,6 +45,7 @@ gulp.task('uglify:resources:dist', function(cb) {
             if (!err) {
               resolve();
             } else {
+              console.log(err);
               reject(err);
             }
           });


### PR DESCRIPTION
If uglify task stops due to an error, reject(err) does not point to exact location of error, i.e. name of script which couldn't be minified and line number, console.log(err) on the other hand does