### PR TITLE
Sass compile performance bugfix

### DIFF
--- a/config.js
+++ b/config.js
@@ -187,7 +187,8 @@ module.exports = {
   },
 
   webpack: {
-    ignoreList: ['/**/*.spec.ts']
+    ignoreList: ['/**/*.spec.ts'],
+    watchScss: false
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp-cssstats": "1.0.1",
     "gulp-debug": "3.2.0",
     "gulp-declare": "0.3.0",
+    "gulp-dependents": "1.2.3",
     "gulp-eslint": "4.0.2",
     "gulp-favicons": "2.2.7",
     "gulp-filter": "5.1.0",

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -8,6 +8,7 @@ gulp.task('resources:sass', function() {
     const autoprefixer = require('autoprefixer');
     const sourcemaps = require('gulp-sourcemaps');
     const cached = require('gulp-cached');
+    const dependents = require('gulp-dependents');
 
     return gulp
       .src([
@@ -15,6 +16,7 @@ gulp.task('resources:sass', function() {
         '!' + config.global.src + config.global.resources + '/scss/**/_*.scss'
       ])
       .pipe(cached('resourcesSass'))
+      .pipe(dependents())
       .pipe(sourcemaps.init())
       .pipe(sass(config.sass).on('error', sass.logError))
       .pipe(postcss([autoprefixer(config.autoprefixer)]))
@@ -39,6 +41,7 @@ gulp.task('components:sass', function() {
     const autoprefixer = require('autoprefixer');
     const sourcemaps = require('gulp-sourcemaps');
     const cached = require('gulp-cached');
+    const dependents = require('gulp-dependents');
 
     return gulp
       .src([
@@ -46,6 +49,7 @@ gulp.task('components:sass', function() {
         '!' + config.global.src + config.global.components + '/**/_*.scss'
       ])
       .pipe(cached('componentsSass'))
+      .pipe(dependents())
       .pipe(sourcemaps.init())
       .pipe(sass(config.sass).on('error', sass.logError))
       .pipe(postcss([autoprefixer(config.autoprefixer)]))
@@ -148,8 +152,7 @@ gulp.task('watch:components:sass', function() {
     watch(components, config.watch, function() {
       runSequence(
         ['lint:components:sass'],
-        ['components:sass'],
-        ['resources:sass'],
+        ['components:sass', 'resources:sass'],
         ['livereload']
       );
     });

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -12,8 +12,7 @@ gulp.task('resources:sass', function() {
 
     return gulp
       .src([
-        config.global.src + config.global.resources + '/scss/**/*.scss',
-        '!' + config.global.src + config.global.resources + '/scss/**/_*.scss'
+        config.global.src + config.global.resources + '/scss/**/*.scss'
       ])
       .pipe(cached('resourcesSass'))
       .pipe(dependents())
@@ -45,8 +44,7 @@ gulp.task('components:sass', function() {
 
     return gulp
       .src([
-        config.global.src + config.global.components + '/**/*.scss',
-        '!' + config.global.src + config.global.components + '/**/_*.scss'
+        config.global.src + config.global.components + '/**/*.scss'
       ])
       .pipe(cached('componentsSass'))
       .pipe(dependents())

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -24,15 +24,20 @@ const webpackSourcePatterns = [
   )
 ];
 const webpackWatchPatterns = [
-  ...webpackSourcePatterns,
-  path.join(
-    config.global.cwd,
-    config.global.src,
-    config.global.components,
-    '**',
-    '*.scss'
-  )
+  ...webpackSourcePatterns
 ];
+
+if (config.webpack.watchScss) {
+  webpackWatchPatterns.push(
+    path.join(
+      config.global.cwd,
+      config.global.src,
+      config.global.components,
+      '**',
+      '*.scss'
+    )
+  );
+}
 
 gulp.task('webpack:ts', function (cb) {
   if (config.global.tasks.webpack) {


### PR DESCRIPTION
added gulp-dependents to resolve imports
made webpack scss entries configurable (switched off by default)
run resources:sass and components:sass parallel