### PR TITLE
fix open browser for windows

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -14,6 +14,9 @@ gulp.task('livereload', function () {
 
 gulp.task('connect:open', function () {
   const opn = require('opn');
+  if (config.connect.host === '0.0.0.0') {
+    return opn(`http://localhost:${config.connect.port}`);
+  }
   return opn(`http://${config.connect.host}:${config.connect.port}`);
 });
 


### PR DESCRIPTION
Windows has a problem with opening `0.0.0.0` i don't know why but `localhost` and `127.0.0.1` works fine. Using `0.0.0.0` by default enables us listen on every host instead of only e.g. `localhost`. 

This fix just checks if the default `0.0.0.0` is enabled and the opens `localhost`

Fixes #181 