### PR TITLE
clean copy task

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ gulp.task('build:dev', function (callback) {
       'svgSprite',
       'copy:dev:npm:js',
       'copy:dev:npm:css',
-      'copy:dev:npm:bower',
       'init:hb2'
     ],
     [
@@ -42,9 +41,12 @@ gulp.task('build:dev', function (callback) {
       'static:hb2'
     ],
     [
+      // needs to be independent, so ts and sass overrides default files
+      'copy:dev:components:files'
+    ],
+    [
       'sass',
-      'webpack:ts',
-      'copy:dev:components:js'
+      'webpack:ts'
     ],
     [
       'modernizr',
@@ -63,7 +65,7 @@ gulp.task('build', function (callback) {
       'build:dev'
     ],
     [
-      'copy:dev:js'
+      'copy:dev:resources:js'
     ],
     [
       'useref'
@@ -75,23 +77,20 @@ gulp.task('build', function (callback) {
       'favicons'
     ],
     [
-      'copy:dist:js',
-      'copy:dist:react',
-      'copy:dist:ts',
-      'copy:dist:flash',
-      'copy:dist:json',
-      'copy:dist:fonts',
+      'copy:dist:resources:js',
+      'copy:dist:resources:react',
+      'copy:dist:resources:ts-js',
+      'copy:dist:resources:json',
+      'copy:dist:resources:fonts',
       'copy:dist:resources:img',
-      'copy:dist:components:img',
-      'copy:dist:assets',
-      'copy:dist:css',
-      'copy:dist:mock',
+      'copy:dist:resources:assets',
+      'copy:dist:resources:css',
+      'copy:dist:resources:components',
+      'copy:dist:resources:hbs',
       'copy:dist:component:mock',
-      'copy:dist:component:data',
+      'copy:dist:components:files',
       'copy:dist:config',
-      'copy:dist:hbs',
-      'copy:dist:bower',
-      'copy:dist:components',
+      'copy:dist:mock',
       'copy:dist:svgSprite'
     ],
     [
@@ -120,7 +119,7 @@ gulp.task('serve', function (callback) {
       'watch:partials:hb2',
       'watch:jsons:hb2',
       'watch:icons:hb2',
-      'watch:components:js',
+      'watch:components:files',
       'watch:sass',
       'watch:eslint:components',
       'watch:eslint:resources',

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -7,8 +7,61 @@ const copyFiles = (from, to) => {
     .pipe(gulp.dest(to));
 };
 
+const ignoreTS = path.join(
+  config.global.cwd,
+  config.global.src,
+  config.global.components,
+  '**',
+  '*.ts'
+);
+const ignoreScss = path.join(
+  config.global.cwd,
+  config.global.src,
+  config.global.components,
+  '**',
+  '*.scss'
+);
 
-gulp.task('copy:dev:js', function () {
+const componentsFilesGlobPattern = [
+  path.join(
+    config.global.cwd,
+    config.global.src,
+    config.global.components,
+    '**',
+    '*'
+  ),
+  `!${path.join(
+    config.global.cwd,
+    config.global.src,
+    config.global.components,
+    '**',
+    '_*'
+  )}`,
+  `!${path.join(
+    config.global.cwd,
+    config.global.src,
+    config.global.components,
+    '**',
+    '_*',
+    '**'
+  )}`,
+  `!${ignoreTS}`,
+  `!${ignoreScss}`
+];
+
+gulp.task('copy:dev:components:files', function () {
+  const from = componentsFilesGlobPattern;
+  const to = path.join(
+    config.global.cwd,
+    config.global.dev,
+    config.global.resources,
+    config.global.components
+  );
+
+  return copyFiles(from, to);
+});
+
+gulp.task('copy:dev:resources:js', function () {
   const from = path.join(
     config.global.cwd,
     config.global.src,
@@ -27,17 +80,11 @@ gulp.task('copy:dev:js', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dev:components:js', function () {
-  const from = path.join(
-    config.global.cwd,
-    config.global.src,
-    config.global.components,
-    '**',
-    '*.js'
-  );
+gulp.task('copy:dist:components:files', function () {
+  const from = componentsFilesGlobPattern;
   const to = path.join(
     config.global.cwd,
-    config.global.dev,
+    config.global.dist,
     config.global.resources,
     config.global.components
   );
@@ -45,7 +92,7 @@ gulp.task('copy:dev:components:js', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:js', function () {
+gulp.task('copy:dist:resources:js', function () {
   const from = path.join(
     config.global.cwd,
     config.global.dev,
@@ -64,7 +111,7 @@ gulp.task('copy:dist:js', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:react', function () {
+gulp.task('copy:dist:resources:react', function () {
   const from = path.join(
     config.global.cwd,
     config.global.dev,
@@ -83,7 +130,7 @@ gulp.task('copy:dist:react', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:ts', function () {
+gulp.task('copy:dist:resources:ts-js', function () {
   const from = path.join(
     config.global.cwd,
     config.global.dev,
@@ -102,7 +149,7 @@ gulp.task('copy:dist:ts', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:components', function () {
+gulp.task('copy:dist:resources:components', function () {
   const from = path.join(
     config.global.cwd,
     config.global.dev,
@@ -183,93 +230,7 @@ gulp.task('copy:dev:npm:css', function () {
   );
 });
 
-/**
- * backwards compatibility for bower components
- * dev copy task
- */
-gulp.task('copy:dev:npm:bower', function () {
-  const mergeStream = require('merge-stream');
-  const bowerResources = config.global.bowerResources;
-
-  if (
-    Object.keys(bowerResources).length === 0 &&
-    bowerResources.constructor === Object
-  ) {
-    return;
-  }
-
-  return mergeStream(
-    Object.keys(bowerResources).map(function (key) {
-      if (typeof bowerResources[key] === 'string') {
-        bowerResources[key] = [bowerResources[key]];
-      }
-
-      return mergeStream(
-        bowerResources[key].map(function (file) {
-          const paths = file.split('/');
-          paths.pop();
-
-          const filePath = path.join(key, ...paths);
-
-          return gulp
-            .src(config.global.node + '/' + key + '/' + file)
-            .pipe(
-              gulp.dest(
-                config.global.dev +
-                config.global.resources +
-                '/bower_components/' +
-                filePath
-              )
-            );
-        })
-      );
-    })
-  );
-});
-
-/**
- * backwards compatibility for bower
- * dist copy task
- */
-gulp.task('copy:dist:bower', function () {
-  const from = path.join(
-    config.global.cwd,
-    config.global.dev,
-    config.global.resources,
-    'bower_components',
-    '**',
-    '*'
-  );
-  const to = path.join(
-    config.global.cwd,
-    config.global.dist,
-    config.global.resources,
-    'bower_components'
-  );
-
-  return copyFiles(from, to);
-});
-
-gulp.task('copy:dist:flash', function () {
-  const from = path.join(
-    config.global.cwd,
-    config.global.src,
-    config.global.resources,
-    'flash',
-    '**',
-    '*'
-  );
-  const to = path.join(
-    config.global.cwd,
-    config.global.dist,
-    config.global.resources,
-    'flash'
-  );
-
-  return copyFiles(from, to);
-});
-
-gulp.task('copy:dist:json', function () {
+gulp.task('copy:dist:resources:json', function () {
   const from = path.join(
     config.global.cwd,
     config.global.src,
@@ -288,7 +249,7 @@ gulp.task('copy:dist:json', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:fonts', function () {
+gulp.task('copy:dist:resources:fonts', function () {
   const from = [
     path.join(
       config.global.cwd,
@@ -336,30 +297,11 @@ gulp.task('copy:dist:resources:img', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:components:img', function () {
+gulp.task('copy:dist:resources:assets', function () {
   const from = path.join(
     config.global.cwd,
     config.global.src,
-    config.global.components,
-    '**',
-    'img',
-    '**',
-    '*'
-  );
-  const to = path.join(
-    config.global.cwd,
-    config.global.dist,
     config.global.resources,
-    config.global.components
-  );
-
-  return copyFiles(from, to);
-});
-
-gulp.task('copy:dist:assets', function () {
-  const from = path.join(
-    config.global.cwd,
-    config.global.src,
     '_assets',
     '**',
     '*'
@@ -373,7 +315,7 @@ gulp.task('copy:dist:assets', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:css', function () {
+gulp.task('copy:dist:resources:css', function () {
   const from = path.join(
     config.global.cwd,
     config.global.src,
@@ -428,25 +370,6 @@ gulp.task('copy:dist:component:mock', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:component:data', function () {
-  const from = path.join(
-    config.global.cwd,
-    config.global.src,
-    config.global.components,
-    '**',
-    'data',
-    '**',
-    '*'
-  );
-  const to = path.join(
-    config.global.cwd,
-    config.global.dist,
-    config.global.components
-  );
-
-  return copyFiles(from, to);
-});
-
 gulp.task('copy:dist:config', function () {
   const from = path.join(
     config.global.cwd,
@@ -464,7 +387,7 @@ gulp.task('copy:dist:config', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('copy:dist:hbs', function () {
+gulp.task('copy:dist:resources:hbs', function () {
   const from = path.join(
     config.global.cwd,
     config.global.src,
@@ -512,21 +435,14 @@ gulp.task('copy:dist:svgSprite', function () {
   return copyFiles(from, to);
 });
 
-gulp.task('watch:components:js', function () {
+gulp.task('watch:components:files', function () {
   const watch = require('gulp-watch');
   const runSequence = require('run-sequence');
-
   watch(
-    path.join(
-      config.global.cwd,
-      config.global.src,
-      config.global.components,
-      '**',
-      '*.js'
-    ),
+    componentsFilesGlobPattern,
     config.watch,
     function () {
-      runSequence(['copy:dev:components:js']);
+      runSequence(['copy:dev:components:files']);
     }
   );
 });

--- a/tasks/image.js
+++ b/tasks/image.js
@@ -1,7 +1,7 @@
 const gulp = require('gulp');
 const config = require('./../config');
 
-gulp.task('image:resources:dist', function() {
+gulp.task('image:resources:dist', function () {
   if (config.global.tasks.image) {
     const path = require('path');
     const image = require('gulp-imagemin');
@@ -20,14 +20,13 @@ gulp.task('image:resources:dist', function() {
           '**',
           '*.*'
         ),
-        '!' +
-          path.join(
-            config.global.dist,
-            config.global.resources,
-            'img',
-            '**',
-            '*.svg'
-          )
+        `!${path.join(
+          config.global.dist,
+          config.global.resources,
+          'img',
+          '**',
+          '*.svg'
+        )}`
       ])
       .pipe(image(imageOptimizers, config.image))
       .pipe(
@@ -39,7 +38,7 @@ gulp.task('image:resources:dist', function() {
   }
 });
 
-gulp.task('image:component:dist', function() {
+gulp.task('image:component:dist', function () {
   if (config.global.tasks.image) {
     const path = require('path');
     const image = require('gulp-imagemin');
@@ -60,16 +59,15 @@ gulp.task('image:component:dist', function() {
           '**',
           '*.*'
         ),
-        '!' +
-          path.join(
-            config.global.dist,
-            config.global.resources,
-            config.global.components,
-            '**',
-            'img',
-            '**',
-            '*.svg'
-          )
+        `!${path.join(
+          config.global.dist,
+          config.global.resources,
+          config.global.components,
+          '**',
+          'img',
+          '**',
+          '*.svg'
+        )}`
       ])
       .pipe(image(imageOptimizers, config.image))
       .pipe(


### PR DESCRIPTION
⚠️ Breaking: remove bower and flash directories

Copies all files inside a component folder that do not start with an underscore, have an underscore in their path or have the extension `ts` or `scss`.

Fixes: #194 #150 