### PR TITLE
Fix/transpilation path

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,7 +20,7 @@ module.exports = {
     dataObject: 'data',
     resources: '/resources',
     components: '/components',
-    handlebarsHelper: '/js/handlebars.helper.js',
+    handlebarsHelper: '/ts/handlebars.helper.js',
     tasks: {
       browserSupport: true,
       cleanCss: true,

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -85,7 +85,7 @@ gulp.task('watch:handlebars', function() {
       config.global.src + config.global.resources + '/hbs/**/*.hbs'
     );
     watchFiles.push(
-      config.global.src + config.global.resources + '/js/handlebars.helper.js'
+      config.global.src + config.global.resources + '/ts/handlebars.helper.js'
     );
     watchFiles.push(
       config.global.src + config.global.components + '/**/hbs/**/*.hbs'

--- a/tasks/hb2.js
+++ b/tasks/hb2.js
@@ -79,13 +79,14 @@ const loadHelpers = () => {
   if (config.global.handlebarsHelper) {
     const projectHbsHelpersPath = path.join(
       config.global.cwd,
-      config.global.src,
+      //config.global.src,
+      config.global.dist,
       config.global.resources,
       config.global.handlebarsHelper
     );
 
     try {
-      const projectHelpers = require(projectHbsHelpersPath);
+      const projectHelpers = require(projectHbsHelpersPath); 
       projectHelpers(handlebars);
     } catch (e) {
       const colors = require('colors/safe');

--- a/tasks/hb2.js
+++ b/tasks/hb2.js
@@ -79,14 +79,13 @@ const loadHelpers = () => {
   if (config.global.handlebarsHelper) {
     const projectHbsHelpersPath = path.join(
       config.global.cwd,
-      //config.global.src,
       config.global.dist,
       config.global.resources,
       config.global.handlebarsHelper
     );
 
     try {
-      const projectHelpers = require(projectHbsHelpersPath); 
+      const projectHelpers = require(projectHbsHelpersPath);
       projectHelpers(handlebars);
     } catch (e) {
       const colors = require('colors/safe');


### PR DESCRIPTION
On the building process, the @biotope/biotope-build was trying to point at a nonexistent path causing a "Cannot find module" message.
This PR aims to solve this problem. 

PS: The files .ts transpiled to .js is being inserted on a **js** folder. Since its expressly written, I assumed this as purposeful and kept this pattern. This problem is not yet entirely solved, but I'll create a new issue for further tracking.  😃 