### PR TITLE
feat: 🎸 enable changing sass compiler via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,14 @@ modernizr: {
 ```
 
 #### sass
-Sass compiler based on node-sass.
+Sass compiler based on node-sass (can be changed to dart-sass via projectConfig.js).
 Repo: https://github.com/dlmanning/gulp-sass
 Options: https://github.com/sass/node-sass#options
 ```
 sass: {
-	includePaths: []
+	includePaths: [],
+	compiler: null // default behaviour. utilizes `node-sass`
+	compiler: require('sass') // overwrite to use `dart-sass` (`sass` package uses `dart-sass` by default nowadays)
 },
 ```
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -21,6 +21,10 @@ gulp.task('sass', function () {
     const dependents = require('gulp-dependents');
     const rename = require('gulp-rename');
 
+    if (config.sass.options.compiler) {
+      sass.compiler = config.sass.options.compiler;
+    }
+
     return gulp
       .src([
         config.global.src + '/**/*.s+(a|c)ss',


### PR DESCRIPTION
This enables changing the SASS compiler by requiring it in a project's `projectConfig.js`. 
--> 
```
module.exports = {
  sass: {
    options: {
      compiler: require('sass')
    }
  }
};